### PR TITLE
Fix Django 1.8 compatibility: rename get_query_set to get_queryset

### DIFF
--- a/django_yubin/managers.py
+++ b/django_yubin/managers.py
@@ -70,7 +70,7 @@ class QueueQuerySet(QueueMethods, models.query.QuerySet):
 class QueueManager(QueueMethods, models.Manager):
     use_for_related_fields = True
 
-    def get_query_set(self):
+    def get_queryset(self):
         return QueueQuerySet(self.model, using=self._db)
 
     def retry_deferred(self, max_retries=None, new_priority=None):


### PR DESCRIPTION
This method name is the reason I moved to django-yubin from django-mailer-2, only to see it isn't 1.8 compatible yet. This PR at least doesn't raise any warnings on Django 1.7.