### PR TITLE
Send test mode

### DIFF
--- a/django_yubin/__init__.py
+++ b/django_yubin/__init__.py
@@ -27,9 +27,13 @@ def send_mail(subject, message, from_email, recipient_list,
 
     """
     from django.core.mail import EmailMessage
-    from django.utils.encoding import force_unicode
+    from django.utils.encoding import force_text
+    from django_yubin import settings
 
-    subject = force_unicode(subject)
+    if settings.MAILER_TEST_MODE and settings.MAILER_TEST_EMAIL:
+        recipient_list = [settings.MAILER_TEST_EMAIL]
+
+    subject = force_text(subject)
     email_message = EmailMessage(subject, message, from_email,
                                  recipient_list)
     queue_email_message(email_message, priority=priority)
@@ -47,13 +51,13 @@ def mail_admins(subject, message, fail_silently=False, priority=None):
 
     """
     from django.conf import settings as django_settings
-    from django.utils.encoding import force_unicode
+    from django.utils.encoding import force_text
     from django_yubin import settings
 
     if priority is None:
         settings.MAIL_ADMINS_PRIORITY
 
-    subject = django_settings.EMAIL_SUBJECT_PREFIX + force_unicode(subject)
+    subject = django_settings.EMAIL_SUBJECT_PREFIX + force_text(subject)
     from_email = django_settings.SERVER_EMAIL
     recipient_list = [recipient[1] for recipient in django_settings.ADMINS]
     send_mail(subject, message, from_email, recipient_list, priority=priority)
@@ -71,13 +75,13 @@ def mail_managers(subject, message, fail_silently=False, priority=None):
 
     """
     from django.conf import settings as django_settings
-    from django.utils.encoding import force_unicode
+    from django.utils.encoding import force_text
     from django_yubin import settings
 
     if priority is None:
         priority = settings.MAIL_MANAGERS_PRIORITY
 
-    subject = django_settings.EMAIL_SUBJECT_PREFIX + force_unicode(subject)
+    subject = django_settings.EMAIL_SUBJECT_PREFIX + force_text(subject)
     from_email = django_settings.SERVER_EMAIL
     recipient_list = [recipient[1] for recipient in django_settings.MANAGERS]
     send_mail(subject, message, from_email, recipient_list, priority=priority)
@@ -103,6 +107,11 @@ def queue_email_message(email_message, fail_silently=False, priority=None):
     if constants.PRIORITY_HEADER in email_message.extra_headers:
         priority = email_message.extra_headers.pop(constants.PRIORITY_HEADER)
         priority = constants.PRIORITIES.get(priority.lower())
+
+    if settings.MAILER_TEST_MODE and settings.MAILER_TEST_EMAIL:
+        email_message.to = [settings.MAILER_TEST_EMAIL]
+        email_message.cc = []
+        email_message.bcc = []
 
     if priority == constants.PRIORITY_EMAIL_NOW:
         if constants.EMAIL_BACKEND_SUPPORT:

--- a/django_yubin/settings.py
+++ b/django_yubin/settings.py
@@ -27,3 +27,8 @@ LOCK_WAIT_TIMEOUT = max(getattr(settings, "MAILER_LOCK_WAIT_TIMEOUT", 0), 0)
 # An optional alternate lock path, potentially useful if you have multiple
 # projects running on the same server.
 LOCK_PATH = getattr(settings, "MAILER_LOCK_PATH", None)
+
+# When MAILER_TEST_MODE is True, recipient addresses of all messages are replaced with
+# the email addresses set in MAILER_TEST_EMAIL before being sent
+MAILER_TEST_MODE = getattr(settings, "MAILER_TEST_MODE", False)
+MAILER_TEST_EMAIL = getattr(settings, "MAILER_TEST_EMAIL", '')

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -72,6 +72,8 @@ MAILER_TEST_MODE
 
 When MAILER_TEST_MODE is ``True``, recipient addresses of all sent messages are replaced with
 the value of the MAILER_TEST_EMAIL setting, before being sent.
+An additional header ``X-Yubin-Test-Original`` will be inserted, with the content of the original
+recipient addresses.
 
 Both, MAILER_TEST_MODE and MAILER_TEST_EMAIL, must evaluate to ``True`` to activate this mode.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -30,7 +30,7 @@ MAILER_MAIL_ADMINS_PRIORITY
 ---------------------------
 
 The default priority for messages sent via the ``mail_admins`` function of
-Django Yubin. 
+Django Yubin.
 
 The default value is ``constants.PRIORITY_HIGH``. Valid values are ``None``
 or any of the priority from ``django_yubin.constants``:
@@ -51,10 +51,10 @@ The default value is ``None``. Valid values are the same as for
 MAILER_EMPTY_QUEUE_SLEEP
 ------------------------
 
-For use with the ``django_yubin.engine.send_loop`` helper function. 
+For use with the ``django_yubin.engine.send_loop`` helper function.
 
 When queue is empty, this setting controls how long to wait (in seconds)
-before checking again. Defaults to ``30``. 
+before checking again. Defaults to ``30``.
 
 
 MAILER_LOCK_WAIT_TIMEOUT
@@ -66,3 +66,20 @@ place.
 
 The default value is ``-1`` which means to never wait for the lock to be
 available.
+
+MAILER_TEST_MODE
+----------------
+
+When MAILER_TEST_MODE is ``True``, recipient addresses of all sent messages are replaced with
+the value of the MAILER_TEST_EMAIL setting, before being sent.
+
+Both, MAILER_TEST_MODE and MAILER_TEST_EMAIL, must evaluate to ``True`` to activate this mode.
+
+Defaults to ``False``.
+
+MAILER_TEST_EMAIL
+-------------------------
+
+String with the email where all email are sent When MAILER_TEST_MODE is on.
+
+Defaults to ``''``.

--- a/tests/tests/test_backend.py
+++ b/tests/tests/test_backend.py
@@ -7,7 +7,7 @@ from unittest import skipIf
 from django.conf import settings as django_settings
 from django.core import mail
 
-from django_yubin import models, constants, queue_email_message
+from django_yubin import models, constants, queue_email_message, settings, mail_admins, mail_managers
 
 from .base import MailerTestCase, RFC_6532_SUPPORT
 
@@ -127,3 +127,38 @@ class TestBackend(MailerTestCase):
 
         queued_messages = models.QueuedMessage.objects.all()
         self.assertEqual(queued_messages.count(), 0)
+
+    def testSendMessageTestMode(self):
+        # Test mode activated
+        settings.MAILER_TEST_MODE = True
+        settings.MAILER_TEST_EMAIL = 'test_email@abc.com'
+        msg = mail.EmailMessage(subject='subject', body='body',
+                                from_email='mail_from@abc.com', to=['mail_to@abc.com'])
+        self.send_message(msg)
+
+        queued_messages = models.QueuedMessage.objects.all()
+
+        self.assertEqual('test_email@abc.com', queued_messages[0].message.to_address)
+        self.assertTrue('test_email@abc.com' in queued_messages[0].message.encoded_message)
+
+    def testSendMessageAdminTestMode(self):
+        # Test mode activated sending mail to admins
+        settings.MAILER_TEST_MODE = True
+        settings.MAILER_TEST_EMAIL = 'test_email@abc.com'
+        mail_admins(subject='subject', message='message')
+
+        queued_messages = models.QueuedMessage.objects.all()
+
+        self.assertEqual('test_email@abc.com', queued_messages[0].message.to_address)
+        self.assertTrue('test_email@abc.com' in queued_messages[0].message.encoded_message)
+
+    def testSendMessageManagersTestMode(self):
+        # Test mode activated sending mail to admins
+        settings.MAILER_TEST_MODE = True
+        settings.MAILER_TEST_EMAIL = 'test_email@abc.com'
+        mail_managers(subject='subject', message='message')
+
+        queued_messages = models.QueuedMessage.objects.all()
+
+        self.assertEqual('test_email@abc.com', queued_messages[0].message.to_address)
+        self.assertTrue('test_email@abc.com' in queued_messages[0].message.encoded_message)

--- a/tests/tests/test_backend.py
+++ b/tests/tests/test_backend.py
@@ -140,6 +140,8 @@ class TestBackend(MailerTestCase):
 
         self.assertEqual('test_email@abc.com', queued_messages[0].message.to_address)
         self.assertTrue('test_email@abc.com' in queued_messages[0].message.encoded_message)
+        self.assertTrue('X-Yubin-Test-Original: mail_to@abc.com' in
+                        queued_messages[0].message.encoded_message)
 
     def testSendMessageAdminTestMode(self):
         # Test mode activated sending mail to admins
@@ -148,9 +150,12 @@ class TestBackend(MailerTestCase):
         mail_admins(subject='subject', message='message')
 
         queued_messages = models.QueuedMessage.objects.all()
+        recipient_list = [recipient[1] for recipient in django_settings.ADMINS]
 
         self.assertEqual('test_email@abc.com', queued_messages[0].message.to_address)
         self.assertTrue('test_email@abc.com' in queued_messages[0].message.encoded_message)
+        self.assertTrue('X-Yubin-Test-Original: {}'.format(','.join(recipient_list)) in
+                        queued_messages[0].message.encoded_message)
 
     def testSendMessageManagersTestMode(self):
         # Test mode activated sending mail to admins
@@ -159,6 +164,9 @@ class TestBackend(MailerTestCase):
         mail_managers(subject='subject', message='message')
 
         queued_messages = models.QueuedMessage.objects.all()
+        recipient_list = [recipient[1] for recipient in django_settings.MANAGERS]
 
         self.assertEqual('test_email@abc.com', queued_messages[0].message.to_address)
         self.assertTrue('test_email@abc.com' in queued_messages[0].message.encoded_message)
+        self.assertTrue('X-Yubin-Test-Original: {}'.format(','.join(recipient_list)) in
+                        queued_messages[0].message.encoded_message)


### PR DESCRIPTION
Create a send e-mail test mode. When this mode is activated, all mails original recipients are replaced with a test email address.
See #15 