### PR TITLE
Only warn if Yubin deferred or skipped mail

### DIFF
--- a/django_yubin/engine.py
+++ b/django_yubin/engine.py
@@ -108,7 +108,7 @@ def send_all(block_size=500, backend=None):
         logger.debug("Lock released.")
 
     logger.debug("")
-    if sent or deferred or skipped:
+    if deferred or skipped:
         log = logger.warning
     else:
         log = logger.info


### PR DESCRIPTION
It might be a matter of preference, however using loglevel warning for regular behaviour (1 or more emails have been sent successfully) seems incorrect in my eyes.

As such a slight tweak to only use warning when Yubin defers or skips 1 or more emails.