### PR TITLE
Using info instead of warning for retry_deferred and cleanup_mail

### DIFF
--- a/django_yubin/management/commands/cleanup_mail.py
+++ b/django_yubin/management/commands/cleanup_mail.py
@@ -31,6 +31,7 @@ class Command(BaseCommand):
         today = datetime.date.today()
         cutoff_date = today - datetime.timedelta(options['days'])
         count = Message.objects.filter(date_created__lt=cutoff_date).count()
-        Message.objects.filter(date_created__lt=cutoff_date).delete()
-        logger.warning("Deleted %s mails created before %s " %
-                       (count, cutoff_date))
+        if count:
+            Message.objects.filter(date_created__lt=cutoff_date).delete()
+            logger.info("Deleted %s mails created before %s " %
+                        (count, cutoff_date))

--- a/django_yubin/management/commands/retry_deferred.py
+++ b/django_yubin/management/commands/retry_deferred.py
@@ -31,8 +31,9 @@ class Command(BaseCommand):
         count = models.QueuedMessage.objects.retry_deferred(
                                             max_retries=options['max_retries'])
         logger = logging.getLogger('django_yubin.commands.retry_deferred')
-        logger.warning("%s deferred message%s placed back in the queue" %
-                       (count, count != 1 and 's' or ''))
+        if count:
+            logger.info("%s deferred message%s placed back in the queue" %
+                        (count, count != 1 and 's' or ''))
 
         logger.removeHandler(handler)
         connection.close()


### PR DESCRIPTION
As my earlier PR (thanks for merging!) my preference is that warnings are only raised when there is something that needs fixing. 

As such I've downgraded both warnings in retry_deferred and cleanup_mail to info-level, and ensured these are only logged when 1 or more mails are retried/cleaned up. This second change is to avoid redundant 'Deleted 0 mails' and '0 deferred messages' logging (but if you disagree on this I can live with only info-level instead of warnings, if so I'll amend the PR).