### PR TITLE
Limit Emails per Call

### DIFF
--- a/django_yubin/management/commands/send_mail.py
+++ b/django_yubin/management/commands/send_mail.py
@@ -25,6 +25,15 @@ class Command(BaseCommand):
                  'is being cleared).',
         )
         parser.add_argument(
+            '-l',
+            '--message_limit',
+            dest='message_limit',
+            type=int,
+            default=0,
+            help='The maximum number of messages to send from the queue in a single pass'
+                 ' (to avoid email rate throttles).',
+        )
+        parser.add_argument(
             '-c',
             '--count',
             dest='count',
@@ -51,7 +60,7 @@ class Command(BaseCommand):
 
         # if PAUSE_SEND is turned on don't do anything.
         if not settings.PAUSE_SEND:
-            send_all(options['block_size'], backend=settings.USE_BACKEND)
+            send_all(options['block_size'], backend=settings.USE_BACKEND, message_limit=message_limit)
         else:
             logger = logging.getLogger('django_yubin.commands.send_mail')
             logger.warning("Sending is paused, exiting without sending "

--- a/django_yubin/management/commands/send_mail.py
+++ b/django_yubin/management/commands/send_mail.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
 
         # if PAUSE_SEND is turned on don't do anything.
         if not settings.PAUSE_SEND:
-            send_all(options['block_size'], backend=settings.USE_BACKEND, message_limit=message_limit)
+            send_all(options['block_size'], backend=settings.USE_BACKEND, message_limit=options['message_limit'])
         else:
             logger = logging.getLogger('django_yubin.commands.send_mail')
             logger.warning("Sending is paused, exiting without sending "

--- a/tests/tests/test_commands.py
+++ b/tests/tests/test_commands.py
@@ -38,7 +38,28 @@ class TestCommands(MailerTestCase):
         call_command('send_mail', verbosity='0')
         self.assertEqual(queued_messages.count(), 1)
 
-    def test_send_mail_limit(self):
+    def test_send_mail_limit_0(self):
+        """
+        The ``send_mail`` command initiates the sending of messages in the
+        queue. The number to send can be limited, 0 = no limit.
+
+        """
+        # No action is taken if there are no messages.
+        call_command('send_mail', verbosity='0')
+        # Only 1 (non-deferred) queued message will be sent.
+        self.queue_message()
+        self.queue_message()
+        self.queue_message()
+        self.queue_message(subject='deferred')
+        models.QueuedMessage.objects.filter(
+            message__subject__startswith='deferred').update(deferred=now())
+        queued_messages = models.QueuedMessage.objects.all()
+        self.assertEqual(queued_messages.count(), 4)
+        self.assertEqual(len(mail.outbox), 0)
+        call_command('send_mail', verbosity='0', message_limit=0)
+        self.assertEqual(queued_messages.count(), 1)
+
+    def test_send_mail_limit_2(self):
         """
         The ``send_mail`` command initiates the sending of messages in the
         queue. The number to send can be limited.
@@ -58,6 +79,27 @@ class TestCommands(MailerTestCase):
         self.assertEqual(len(mail.outbox), 0)
         call_command('send_mail', verbosity='0', message_limit=2)
         self.assertEqual(queued_messages.count(), 2)
+
+    def test_send_mail_limit_10(self):
+        """
+        The ``send_mail`` command initiates the sending of messages in the
+        queue. The number to send can be limited. Numbers higher than queue should be fine
+
+        """
+        # No action is taken if there are no messages.
+        call_command('send_mail', verbosity='0')
+        # Only 1 (non-deferred) queued message will be sent.
+        self.queue_message()
+        self.queue_message()
+        self.queue_message()
+        self.queue_message(subject='deferred')
+        models.QueuedMessage.objects.filter(
+            message__subject__startswith='deferred').update(deferred=now())
+        queued_messages = models.QueuedMessage.objects.all()
+        self.assertEqual(queued_messages.count(), 4)
+        self.assertEqual(len(mail.outbox), 0)
+        call_command('send_mail', verbosity='0', message_limit=10)
+        self.assertEqual(queued_messages.count(), 1)
 
     def test_retry_deferred(self):
         """


### PR DESCRIPTION
To avoid mail throttles/spamming this adds a message_limit option to limit how many emails can get sent in a single call. I tested this with a number of settings and it's working for me.