### PR TITLE
Update the debug handlers options for verbosity

### DIFF
--- a/django_yubin/management/commands/__init__.py
+++ b/django_yubin/management/commands/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-LOGGING_LEVEL = {'0': logging.ERROR, '1': logging.WARNING, '2': logging.DEBUG}
+LOGGING_LEVEL = {'0': logging.ERROR, '1': logging.WARNING, '2': logging.DEBUG, '3': logging.DEBUG}
 
 
 def create_handler(verbosity, message='%(message)s'):


### PR DESCRIPTION
Since the commands (send_mail etc.) are using the standard -v verbosity in the arg parser, the help for the command shows that there are four verbosity  levels (0-3). At the moment if you run 

python manage.py send_mail -v3 

for instance, it fails with a cryptic message about the key "3" not being present in the LOGGING_LEVEL dictionary. This change duplicates the "2" key so that both 2 and 3 verbosity have the DEBUG message level. 

An alternative would be to specify the -v option in each of the commands to only allow -v[0/1/2].