### PR TITLE
Use settings.MAILER_PAUSE_SEND in all functions that send messages

### DIFF
--- a/django_yubin/admin.py
+++ b/django_yubin/admin.py
@@ -133,6 +133,7 @@ class QueuedMessage(MessageRelatedModelAdmin):
     list_display = ('id', 'message_link', 'message__to_address',
                     'message__from_address', 'message__subject',
                     'message__date_created', 'priority', 'not_deferred')
+    list_filter = ('priority', 'deferred')
 
 
 class Blacklist(admin.ModelAdmin):

--- a/django_yubin/management/commands/send_mail.py
+++ b/django_yubin/management/commands/send_mail.py
@@ -1,13 +1,11 @@
 # encoding: utf-8
 
-import logging
 import sys
 
 from django.core.management.base import BaseCommand
 from django.db import connection
 from django_yubin import models, settings
 from django_yubin.engine import send_all
-from django_yubin.management.commands import create_handler
 
 
 class Command(BaseCommand):
@@ -30,8 +28,8 @@ class Command(BaseCommand):
             dest='message_limit',
             type=int,
             default=0,
-            help='The maximum number of messages to send from the queue in a single pass'
-                 ' (to avoid email rate throttles).',
+            help='The maximum number of messages to send from the queue in a '
+                 'single pass (to avoid email rate throttles).',
         )
         parser.add_argument(
             '-c',
@@ -53,20 +51,9 @@ class Command(BaseCommand):
                                      deferred, deferred != 1 and 's' or ''))
             sys.exit()
 
-        # Send logged messages to the console.
-        logger = logging.getLogger('django_yubin')
-        handler = create_handler(verbosity)
-        logger.addHandler(handler)
-
-        # if PAUSE_SEND is turned on don't do anything.
-        if not settings.PAUSE_SEND:
-            send_all(options['block_size'], backend=settings.USE_BACKEND, message_limit=options['message_limit'])
-        else:
-            logger = logging.getLogger('django_yubin.commands.send_mail')
-            logger.warning("Sending is paused, exiting without sending "
-                           "queued mail.")
-
-        logger.removeHandler(handler)
+        send_all(options['block_size'],
+                 backend=settings.USE_BACKEND,
+                 message_limit=options['message_limit'])
 
         # Stop superfluous "unexpected EOF on client connection" errors in
         # Postgres log files caused by the database connection not being

--- a/django_yubin/models.py
+++ b/django_yubin/models.py
@@ -19,7 +19,7 @@ PRIORITIES = (
 
 RESULT_CODES = (
     (constants.RESULT_SENT, 'success'),
-    (constants.RESULT_SKIPPED, 'not sent (blacklisted)'),
+    (constants.RESULT_SKIPPED, 'not sent (blacklisted or paused)'),
     (constants.RESULT_FAILED, 'failure'),
 )
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -13,8 +13,7 @@ MAILER_PAUSE_SEND
 Provides a way of temporarily pausing the sending of mail. Defaults to
 ``False``.
 
-If this setting is ``True``, mail will not be sent when the ``send_mail``
-command is called.
+If this setting is ``True``, mail will not be sent by any function.
 
 
 MAILER_USE_BACKEND

--- a/tests/tests/test_engine.py
+++ b/tests/tests/test_engine.py
@@ -8,6 +8,7 @@ import time
 from io import StringIO
 
 from django.conf import settings as django_settings
+from django.core import mail
 from django.test import TestCase
 
 from lockfile import FileLock
@@ -133,5 +134,19 @@ class SendMessageTest(MailerTestCase):
         q_message = models.QueuedMessage.objects.first()
         _original, settings.PAUSE_SEND = settings.PAUSE_SEND, True
         result = engine.send_queued_message(q_message)
+        settings.PAUSE_SEND = _original
+        self.assertEqual(result, constants.RESULT_SKIPPED)
+
+    def test_send_message(self):
+        email_message = mail.EmailMessage('subject', 'body', 'from@email.com',
+                                          ['to@email.com'])
+        result = engine.send_message(email_message)
+        self.assertEqual(result, constants.RESULT_SENT)
+
+    def test_pause_send_message(self):
+        email_message = mail.EmailMessage('subject', 'body', 'from@email.com',
+                                          ['to@email.com'])
+        _original, settings.PAUSE_SEND = settings.PAUSE_SEND, True
+        result = engine.send_message(email_message)
         settings.PAUSE_SEND = _original
         self.assertEqual(result, constants.RESULT_SKIPPED)


### PR DESCRIPTION
Before, settings.MAILER_PAUSE_SEND was used only in send_mail command, now it's used in all functions that make a connection to send the message.