### PR TITLE
(fix) UnicodeEncodeError when priority is 'now-not-queued'

### DIFF
--- a/django_yubin/engine.py
+++ b/django_yubin/engine.py
@@ -260,7 +260,8 @@ def send_message(email_message, smtp_connection=None):
         smtp_connection.connection.sendmail(
             email_message.from_email,
             email_message.recipients(),
-            email_message.message().as_string())
+            smart_str(email_message.message().as_string()
+                      ).encode('utf-8'))
         result = constants.RESULT_SENT
     except (SocketError, smtplib.SMTPSenderRefused,
             smtplib.SMTPRecipientsRefused,

--- a/django_yubin/smtp_queue.py
+++ b/django_yubin/smtp_queue.py
@@ -9,10 +9,9 @@ from django.core.mail.backends.base import BaseEmailBackend
 
 
 class EmailBackend(BaseEmailBackend):
-    '''
+    """
     A wrapper that manages a queued SMTP system.
-
-    '''
+    """
 
     def send_messages(self, email_messages):
         """
@@ -33,6 +32,6 @@ class EmailBackend(BaseEmailBackend):
 
         num_sent = 0
         for email_message in email_messages:
-            queue_email_message(email_message)
-            num_sent += 1
+            if queue_email_message(email_message):
+                num_sent += 1
         return num_sent


### PR DESCRIPTION
When trying to send email with priority 'now-not-queued' I can see in
the errors files messages as :

```
failed due to: 'ascii' codec can't encode character '\xf3' in position 481: ordinal not in range(128)
```

This is the summarize:

* Add testUnicodePriorityNowNotQueuedMessage
* Bug fix for UnicodeEncodeError when priority is 'now-not-queued'
* Bug fix for counting num_sent emailsI
* Change models.QueuedMessage.objects.all() -> models.QueuedMessage.objects.filter(deferred__isnull=True) to check there is not deferred