### PR TITLE
Detecting more encoding headers to be able to preview messages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,7 @@ You can read the package documentation at http://django-yubin.readthedocs.org/en
 
 Changelog
 ---------
+* 1.4.1       Detecting if messages are encoding using different encoding headers to be able to preview them (now base64, quoted-printable).
 * 1.4.0       Option added in status_mail command to return the output in json format.
 * 1.3.1       Fix unicode and encode errors: sending queued and non queued emails and in admin detail view.
 * 1.3.0       Allow to send emails inmediatly without being saved in database (priority «now-not-queued»). Add support for Python 3.7 and Django 2.1. Remove old code for Django < 1.3.

--- a/django_yubin/admin.py
+++ b/django_yubin/admin.py
@@ -98,7 +98,7 @@ class Message(admin.ModelAdmin):
 
     @staticmethod
     def _is_encoding_header(header_name):
-        return header_name in ['base64', 'quoted-printable', '7bit']
+        return header_name in ['base64', 'quoted-printable']
 
     @staticmethod
     def is_encoded(msg, part='html_part'):

--- a/django_yubin/admin.py
+++ b/django_yubin/admin.py
@@ -74,9 +74,9 @@ class Message(admin.ModelAdmin):
         context = {'subject': msg.get_subject(), 'from': msg.get_address('from'), 'to': msg.get_addresses('to'),
                    'cc': msg.get_addresses('cc'),
                    'msg_text': msg.text_part.part.get_payload(
-                       decode=self.is_base64(msg, 'text_part')) if msg.text_part else None,
+                       decode=self.is_encoded(msg, 'text_part')) if msg.text_part else None,
                    'msg_html': msg.html_part.part.get_payload(
-                       decode=self.is_base64(msg, 'html_part')) if msg.html_part else None,
+                       decode=self.is_encoded(msg, 'html_part')) if msg.html_part else None,
                    'attachments': get_attachments(msg), 'is_popup': True, 'object': instance}
         return render(request, 'django_yubin/message_detail.html', context)
 
@@ -93,21 +93,25 @@ class Message(admin.ModelAdmin):
         instance = models.Message.objects.get(pk=pk)
         msg = instance.get_pyz_message()
         msg.html_part.part._charset = 'utf-8'
-        context = {'msg_html': msg.html_part.part.get_payload(decode=self.is_base64(msg, 'html_part'))}
+        context = {'msg_html': msg.html_part.part.get_payload(decode=self.is_encoded(msg, 'html_part'))}
         return render(request, 'django_yubin/html_detail.html', context)
 
     @staticmethod
-    def is_base64(msg, part='html_part'):
+    def _is_encoding_header(header_name):
+        return header_name in ['base64', 'quoted-printable', '7bit']
+
+    @staticmethod
+    def is_encoded(msg, part='html_part'):
         """
-        detect whether is a base64 encoding or not
+        detect whether the part is encoded or not. We'll check for known encoding headers
 
         :param msg, part:
         :return:
         """
         if part == 'html_part':
-            return any(it[1] == 'base64' for it in msg.html_part.part._headers)
+            return any(Message._is_encoding_header(header[1]) for header in msg.html_part.part._headers)
         elif part == 'text_part':
-            return any(it[1] == 'base64' for it in msg.text_part.part._headers)
+            return any(Message._is_encoding_header(header[1]) for header in msg.text_part.part._headers)
         return False
 
 


### PR DESCRIPTION
Detecting more than "base64" encoding to be able to preview messages that use other encodings.

No tests have been added as I couldn't find a quick way to add tests for the "admin" site.
This PR shouldn't impact the messages that use base64 encoding, so it won't have any side-effects.