### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Advantages
 
 * Yubin allows to define prioritary queues, resend e-mails
 
-* Yubin helps in your development.  It's a good way to work when you're developping
+* Yubin helps in your development.  It's a good way to work when you're developing
   the application and you don't want to flood your test users with
   e-mails. With Django Yubin, and without running the cron commands, you can see how
   your e-mails are, retrieve them and even delete them with out sending it.
@@ -66,7 +66,7 @@ someting like
 
 This will send the queued e-mail every minute.
 
-Django Yubin is a fork from django-mailer2 with some addtions from django-mailviews and
+Django Yubin is a fork from django-mailer2 with some additions from django-mailviews and
 additional improvements made from apsl.net that we need for our daly basis workd. It
 has also contributions from other people, so don't heasitate to read the humans.txt.
 
@@ -94,7 +94,7 @@ Changelog
 * 1.4.1       Detecting if messages are encoding using different encoding headers to be able to preview them (now base64, quoted-printable).
 * 1.4.0       Option added in status_mail command to return the output in json format.
 * 1.3.1       Fix unicode and encode errors: sending queued and non queued emails and in admin detail view.
-* 1.3.0       Allow to send emails inmediatly without being saved in database (priority «now-not-queued»). Add support for Python 3.7 and Django 2.1. Remove old code for Django < 1.3.
+* 1.3.0       Allow to send emails immediately without being saved in database (priority «now-not-queued»). Add support for Python 3.7 and Django 2.1. Remove old code for Django < 1.3.
 * 1.2.0       Fix is_base64 detection. Add a «send_test_email» command to check connection parameters. New health check view. Don't open a connection if there are no messages in queue to send. Add a "date_sent" field to detect when the mail was sent.
 * 1.1.0       Fix attachment headers in TemplateAttachmentEmailMessagView making both "attachment" and "filename" args mandatory.
 * 1.0.5       Add missing paths in MANIFEST.in.

--- a/django_yubin/admin.py
+++ b/django_yubin/admin.py
@@ -39,7 +39,7 @@ class Message(admin.ModelAdmin):
 
     def re_send(self, request, queryset):
         """
-        Re sends a previus sent e-mail. The messages shouldn't be in the queue and
+        Re sends a previous sent e-mail. The messages shouldn't be in the queue and
         is put in the NORMAL priority
         """
         messages_sent = 0

--- a/django_yubin/messages.py
+++ b/django_yubin/messages.py
@@ -260,7 +260,7 @@ class TemplatedHTMLEmailMessageView(TemplatedEmailMessageView):
 
     def get_context_data(self, **kwargs):
         """
-        As is quite commont to have images in an HTML e-mail add MEDIA_URL
+        As is quite common to have images in an HTML e-mail add MEDIA_URL
         and STATIC_URL to the context with its full path
         """
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -2,7 +2,7 @@
 Contributing
 ============
 
-django-yubin is an open source project and imporvements and bug reports are
+django-yubin is an open source project and improvements and bug reports are
 very appreciated.
 
 You can contribute in many ways:
@@ -18,7 +18,7 @@ Please follow the PEP8 coventions and in case you write additional features don'
 forget to write the tests for them.
 
 At http://apsl.net we use yubin for most of our own projects, so we'll try to
-mantain it as bug free as stable as possible. That said we can't not guarantee
+maintain it as bug free as stable as possible. That said we can't not guarantee
 that we could patch the program in the way you like, add that new feature, etc.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,6 +90,6 @@ Original branch and the django-mailer-2 hard work comes from Chris Beaven.
 
 django-mailviews from Disqus
 
-The name django-yubin was suggested by @morenosan, he says it means "postal mail" in japanesse, but who knows! :)
+The name django-yubin was suggested by @morenosan, he says it means "postal mail" in japanese, but who knows! :)
 
 

--- a/docs/mailviews.rst
+++ b/docs/mailviews.rst
@@ -8,7 +8,7 @@ Rendering and sending emails in Django can quickly become repetitive and
 error-prone. By encapsulating message rendering within view classes, you can
 easily compose messages in a structured and clear manner.
 
-The idea behind the method is identhical to the template class based view: you can select the template to use, in our
+The idea behind the method is identical to the template class based view: you can select the template to use, in our
 case one for the subject and one for the body (and one extra for the html), you can pass the data you need overriding
 the ``get_context_data`` method and the message rendering is made in ``render_to_message`` where you can also customize
 the parameters as sender, cc, cco, etc. or delay the decision to the ``send`` method.

--- a/docs/queue.rst
+++ b/docs/queue.rst
@@ -82,7 +82,7 @@ executing it with cron.
 Health Check
 ============
 
-Go to ``http://yourproject/yubin/health`` for see the health output result. You can see shomething like that:
+Go to ``http://yourproject/yubin/health`` for see the health output result. You can see something like that:
 
 .. code:: text
 


### PR DESCRIPTION
There are small typos in:
- README.rst
- django_yubin/admin.py
- django_yubin/messages.py
- docs/contributing.rst
- docs/index.rst
- docs/mailviews.rst
- docs/queue.rst

Fixes:
- Should read `something` rather than `shomething`.
- Should read `previous` rather than `previus`.
- Should read `maintain` rather than `mantain`.
- Should read `japanese` rather than `japanesse`.
- Should read `improvements` rather than `imporvements`.
- Should read `immediately` rather than `inmediatly`.
- Should read `identical` rather than `identhical`.
- Should read `developing` rather than `developping`.
- Should read `common` rather than `commont`.
- Should read `additions` rather than `addtions`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md