### PR TITLE
Ensure parsed e-mail message is not discarded

### DIFF
--- a/django_yubin/models.py
+++ b/django_yubin/models.py
@@ -131,7 +131,7 @@ class Message(models.Model):
         msg = self.get_message_parser()
         to = self.to() or mailparser_utils.get_addresses(msg.to)
         cc = self.cc() or mailparser_utils.get_addresses(msg.cc)
-        bcc = self.bcc() or mailparser_utils.get_addresses(msg.bcc)
+        bcc = self.bcc()
 
         Email = EmailMultiAlternatives if msg.text_html else EmailMessage
         email = Email(

--- a/tests/tests/test_models.py
+++ b/tests/tests/test_models.py
@@ -1,6 +1,9 @@
 from datetime import timedelta
+from email.mime.image import MIMEImage
+from email.generator import _fmt
 from unittest.mock import patch
 
+from django.core.mail import EmailMultiAlternatives
 from django.test import TestCase
 from django.utils import timezone
 
@@ -103,3 +106,97 @@ class TestMessage(MessageMixin, TestCase):
         messages = Message.objects.all()
         self.assertEqual(len(messages), 1)
         self.assertGreaterEqual(messages[0].date_created, timezone.now() - timedelta(days=days))
+
+    @patch("django.core.mail.message.generator.Generator._make_boundary")
+    def test_get_email_message_roundtrip(self, mock_make_boundary):
+        self.maxDiff = None
+
+        def get_boundary(token: int):
+            return ('=' * 15) + (_fmt % token) + '=='
+
+        boundaries = [get_boundary(10), get_boundary(20), get_boundary(30), get_boundary(40)]
+
+        def reset_mock():
+            assert mock_make_boundary.call_count == 2
+            mock_make_boundary.reset_mock(side_effect=True)
+            mock_make_boundary.side_effect = boundaries
+
+        mock_make_boundary.side_effect = boundaries
+
+        ref = EmailMultiAlternatives(
+            subject="Some subject",
+            body="Plain text body",
+            from_email="from@example.com",
+            to=["to@example.com"],
+            bcc=["bcc@example.com"],
+            cc=["cc@example.com"],
+            headers={"X-Custom": "custom-header"},
+            reply_to=["reply-to@example.com"],
+        )
+        ref.attach_alternative(
+            "<html><body><img src=\"cid:123456789\" /></body></html>",
+            "text/html"
+        )
+        ref.mixed_subtype = "related"
+        # add an inline cid image (PNG, white pixel)
+        image = MIMEImage(
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08"
+            b"\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\x01sRGB\x00\xae\xce\x1c\xe9"
+            b"\x00\x00\x00\rIDAT\x18Wc\xf8\xff\xef\xdf\x7f\x00\t\xf6\x03\xfbW\xfe{\x1b"
+            b"\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+        image.add_header("Content-ID", "<123456789>")
+        ref.attach(image)
+        ref.attach("dummy.pdf", b"mock-data", "application/pdf")
+        ref_msg = ref.message()
+        assert ref_msg["Content-Type"].startswith("multipart/related")
+        ref_as_string = ref_msg.as_string()
+        reset_mock()
+        ref_message_id = ref_msg["Message-ID"]
+        ref_date = ref_msg["Date"]
+
+        # construct model instance and reconstruct the django email message
+        msg = Message(message_data=ref_as_string)
+        reconstructed = msg.get_email_message()
+
+        reconstructed_msg = reconstructed.message()
+
+        with self.subTest(alternative="html"):
+            self.assertEqual(len(reconstructed.alternatives), 1)
+            self.assertEqual(
+                reconstructed.alternatives[0],
+                ("<html><body><img src=\"cid:123456789\" /></body></html>", "text/html")
+            )
+
+        # some tangible checks, but the kicker is really the string comparison
+        for attr in ("subject", "body", "from_email", "to", "cc", "reply_to"):
+            with self.subTest(msg_attr=attr):
+                original = getattr(ref, attr)
+                _reconstructed = getattr(reconstructed, attr)
+
+                self.assertEqual(_reconstructed, original)
+
+        with self.subTest("BCC"):
+            # original message does not store BCC in headers (that beats the point)
+            self.assertEqual(reconstructed.bcc, [])
+
+        with self.subTest("custom headers"):
+            custom_header = reconstructed.extra_headers.get("X-Custom")
+            self.assertEqual(custom_header, "custom-header")
+
+        # Special check for content type
+        with self.subTest("mixed subtype"):
+            content_type = reconstructed.message()["Content-Type"]
+            self.assertTrue(content_type.startswith("multipart/related"))
+
+        # Important to correlate messages in the logs with mail server logs/mail client
+        # reported headers
+        with self.subTest("message ID"):
+            self.assertEqual(reconstructed_msg["Message-ID"], ref_message_id)
+
+        with self.subTest("date"):
+            self.assertEqual(reconstructed_msg["Date"], ref_date)
+
+        with self.subTest("compare message as_string"):
+            self.assertEqual(reconstructed_msg.as_string(), ref_as_string)
+            reset_mock()


### PR DESCRIPTION
Related to #66

* Added extensive regression test. I do not believe this covers all possible situations yet.
* Generalized attachment handling in Message.get_email_message
* Fixed other missing e-mail message information (Reply-To, BCC, custom headers)

The custom header treatment feels a bit fragile, though I do believe that:

* re-using the date from the original queued message makes sense - this is effectlively when the attempt to send the email was given
* re-using the message ID -> this helps correlating what you see in application logging + database log/message entries + mail server logging and final received messages
* message boundaries are re-created when sending them, this requires us to parse the e-mail content type header to determine the appropriate subtype