### PR TITLE
:zap: Fixes #68 -- improve performance of data migration

### DIFF
--- a/django_yubin/migrations/0007_auto_20200319_1158.py
+++ b/django_yubin/migrations/0007_auto_20200319_1158.py
@@ -47,5 +47,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(migrate_to_queues),
+        migrations.RunPython(migrate_to_queues, migrations.RunPython.noop),
     ]


### PR DESCRIPTION
Tested against a 13GB SQL dump of the email table (~23K records), within a cgroup with 300M memory limit. The migration completed in just under 60s.

* Use iterator to avoid loading entire table in memory (for the queryset cache)
* Defer the message content, as it may contain attachments causing excessive memory usage - it is not used in the migration anyway.
* Replace loop over log table with 3 separate SQL update queries