### PR TITLE
Remove upper bound to `celery` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 
 INSTALL_REQUIRES = [
-    'celery>=5.0,<5.3',
+    'celery>=5.0',
     'mail-parser',
     'pytz',
 ]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 
 INSTALL_REQUIRES = [
-    'celery>=5.0',
+    'celery>=5.0,<6',
     'mail-parser',
     'pytz',
 ]


### PR DESCRIPTION
Considering the usage of Celery in the library (only `shared_task`), I don't think adding an upper bound is necessary.